### PR TITLE
Use graceful-fs instead of fs to avoid EMFILE error

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "debuglog": "^1.0.1",
     "dezalgo": "^1.0.0",
+    "graceful-fs": "^3.0.4",
     "once": "^1.3.0"
   },
   "devDependencies": {

--- a/readdir.js
+++ b/readdir.js
@@ -1,4 +1,4 @@
-var fs = require ('fs')
+var fs = require ('graceful-fs')
 var dz = require ('dezalgo')
 var once = require ('once')
 var path = require ('path')


### PR DESCRIPTION
Otherwise you'll get EMFILE errors when reading large node_modules
folders.  This is the root cause of npm/npm#6506.
