### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "debuglog": "^1.0.1",
     "dezalgo": "^1.0.0",
-    "graceful-fs": "^3.0.4",
+    "graceful-fs": "^4.1.2",
     "once": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714